### PR TITLE
Use strrchr() instead of rindex()

### DIFF
--- a/src/perl-mmagic-xs.c
+++ b/src/perl-mmagic-xs.c
@@ -1449,7 +1449,7 @@ fmm_ext_magic(PerlFMM *state, char *file, char **mime_type)
     char ext[BUFSIZ];
     char *temp_mimetype;
     /* Look for the last dot */
-    char *dot = rindex(file, '.');
+    char *dot = strrchr(file, '.');
     if (dot == 0x00) {
         return 0;
     }


### PR DESCRIPTION
This is primarily for Android's libc, bionic, which does
not export a rindex() function.

Looks like this is the recommended way nowadays, too: http://pubs.opengroup.org/onlinepubs/007904975/functions/rindex.html
