### PR TITLE
Grow buffer to HOWMANY bytes before passing it to fmm_bufmagic().

### DIFF
--- a/src/perl-mmagic-xs.c
+++ b/src/perl-mmagic-xs.c
@@ -1616,10 +1616,10 @@ PerlFMM_bufmagic(PerlFMM *self, SV *buf)
 
     /* rt #28040, allow RV to SVs to be passed here */
     if (SvROK(buf) && SvTYPE(SvRV(buf)) == SVt_PV) {
-        buffer = (unsigned char *) SvPV_nolen( SvRV( buf ) );
-    } else {
-        buffer = (unsigned char *) SvPV_nolen(buf);
+        buf = SvRV(buf);
     }
+    SvGROW(buf, HOWMANY + 1);
+    buffer = (unsigned char *) SvPV_nolen(buf);
 
     FMM_SET_ERROR(self, NULL);
 


### PR DESCRIPTION
Fix for File-MMagic-XS-0.09008 crash.
https://rt.cpan.org/Public/Bug/Display.html?id=123503